### PR TITLE
handle packet dropping

### DIFF
--- a/3700recv.py
+++ b/3700recv.py
@@ -3,9 +3,8 @@
 import argparse, socket, time, json, select, struct, sys, math
 
 class Receiver:
-    all = {}
     acked = {}
-    seqn_to_print = 1  # keeps track of which packet to print next
+    seqn_to_print = 0  # keeps track of which packet to print next
 
     def __init__(self):
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -51,14 +50,12 @@ class Receiver:
                 msg = json.loads(data.decode('utf-8'))
                 self.log("Received data message %s" % msg)
                 seqnum = msg["seqnum"] 
-                self.all[seqnum] = msg # necessary?
 
                 self.send_ack(msg, seqnum) # ack no matter if in order or not
 
                 # if in order, recursive print
                 if seqnum == self.seqn_to_print:
                     self.print_recursive(msg)
-                # else: # else, add to to_print
                     
         return
 

--- a/3700recv.py
+++ b/3700recv.py
@@ -3,7 +3,7 @@
 import argparse, socket, time, json, select, struct, sys, math
 
 class Receiver:
-    # dict mapping seqnum -> msg, for packets recieved out of order
+    # dict mapping seqnum -> msg
     stored_data = {}
     expected_seqnum = 1
     seen = []
@@ -26,18 +26,18 @@ class Receiver:
 
     def send_ack(self, msg, seqnum):
         self.log('sending ack for seqn %s' % seqnum)
-        print(msg["data"], end='', flush=True) # print
-        self.send({ "type": "ack", "seqnum": seqnum }) # send the ack
-        self.seen.append(seqnum) # append it to list of seen seq nums
-        self.expected_seqnum += 1 # increment
+        print(msg["data"], end='', flush=True) 
+        self.send({ "type": "ack", "seqnum": seqnum }) 
+        # self.seen.append(seqnum) 
 
     def check_next_ack(self):
-        next_ack = self.stored_data.get(self.expected_seqnum)
-        if next_ack is not None:
-            self.send_ack(next_ack, self.expected_seqnum)
-            self.check_next_ack() # call recursive check for next acks 
-        else:
-            return
+        # next_ack = self.stored_data.get(self.expected_seqnum)
+        # if next_ack is not None:
+        #     self.send_ack(next_ack, self.expected_seqnum)
+        #     self.expected_seqnum += 1 # increment
+        #     self.check_next_ack() # call recursive check for next acks 
+        # else:
+        return
 
     def run(self):
         while True:
@@ -54,22 +54,28 @@ class Receiver:
                 self.log("Received data message %s" % msg)
 
                 seqnum = msg["seqnum"] # get packet seq number
-
-                # if next seq number
-                self.log('if seqnum == self.expected_seqnum: '+ str(seqnum) + '==' + str(self.expected_seqnum) + '?')
-                if seqnum == self.expected_seqnum:
-                    self.send_ack(msg, seqnum)
-                    self.check_next_ack()
-
-                # if duplicate seq number 
-                elif seqnum in self.seen:
-                    self.log("got duplicate packet %s \n" % str(seqnum))
-
-                # if out of order
-                else:
+                curr_try = msg["try"]
+                
+                self.log("expected next packet for %s \n" % str(self.expected_seqnum))
+                # check if we've gotten a version of this packet before
+                existing = self.stored_data.get(seqnum)
+                if existing is not None: # got a duplicate
+                    if seqnum < self.expected_seqnum:
+                        self.log("got duplicate packet %s \n" % str(seqnum))
+                        if curr_try > existing["try"]: # its a retransmission, ack it
+                            self.log("but its a newer version \n")
+                            self.send_ack(msg, seqnum)
+                            self.expected_seqnum = seqnum + 1   # reset expected
+                elif seqnum == self.expected_seqnum: # got the next expected
+                        self.send_ack(msg, seqnum)
+                        self.expected_seqnum += 1 # increment
+                        self.check_next_ack()
+                else: # got an out of order ack
                     self.log("got out of order packet %s \n" % str(seqnum))
-                    # save the datagram to the dict, don't ack yet
-                    self.stored_data[seqnum] = msg
+                    # ack???
+                
+                # save the datagram to the dict
+                self.stored_data[seqnum] = msg
                     
         return
 

--- a/3700send.py
+++ b/3700send.py
@@ -11,6 +11,7 @@ class Sender:
     # seqnum -> time sent
     awaiting_ack = {}
 
+    # seqnum -> msg
     packs = {}
 
     next_seqn = 0  # what we give a new packet thats being sent
@@ -56,7 +57,7 @@ class Sender:
 
             socks = select.select(sockets, [], [], 0.1)[0]
 
-            self.check_timeouts()
+            self.check_timeouts() # check if any packs weve sent have timed out 
 
             for conn in socks:
                 if conn == self.socket:
@@ -100,10 +101,3 @@ if __name__ == "__main__":
     args = parser.parse_args()
     sender = Sender(args.host, args.port)
     sender.run()
-
-
-    # def got_all_acks(self, acks, seqnum):
-    #     for i in range(seqnum):
-    #         if acks[i] != 1:
-    #             return False
-    #     return True


### PR DESCRIPTION
 **sender side:**

- our data structures:
    - `awaiting_ack` dict (seqnum->time sent in sec) keeps track of which packets were sent but haven't been acked yet.
    - `packs` dict (seqnum->msg) stores every packet we've ever sent.

- new logic:
    - we're constantly checking for timeouts on the packets we've sent with `check_timeouts()`.
    - if it's been > 2s since the packet was sent, assume it was dropped and `retransmit()`.

 **receiver side:**

- our data structures:
    - `acked` dict (seqnum->msg) keeps track of all packets we've acked
        - note: this is not the same as all packets we've printed
- new logic:
    - ack _everything_, but print only the msg of the packet with the seqnum in order.

